### PR TITLE
fix: classNames collecting mechanism and prevent collect click data w…

### DIFF
--- a/src/collectHeatmapClicks.js
+++ b/src/collectHeatmapClicks.js
@@ -1,10 +1,14 @@
 export default (subscribe) => {
+  const PPAS_SITE_INSPECTOR_IFRAME_ID = 'ppas_site_inspector';
+  const PPAS_SITE_INSPECTOR_TAG_CONFIG_ID = 'ppas_container_configuration';
+
+  // configuration gathered by extension on initialization
   const injectSevenTagConfiguration = function() {
     if (window.sevenTag) {
       const config = window.sevenTag.configuration;
       const element = document.createElement('script');
 
-      element.id = 'ppas-container-configuration';
+      element.id = PPAS_SITE_INSPECTOR_TAG_CONFIG_ID;
       element.setAttribute('data-appId', config.id);
       element.setAttribute('data-host', config.host);
 
@@ -39,7 +43,7 @@ export default (subscribe) => {
 
       // exclude SVGAnimatedString className objects
       if (typeof element.className === 'string' && element.className) {
-        const classes = element.className.replaceAll(' ', '.');
+        const classes = element.className.replace(/\s+/g, '.');
         tag += `.${classes}`;
       }
 
@@ -49,9 +53,19 @@ export default (subscribe) => {
     return stringSteps.reverse().join('>');
   };
 
+  const isSiteInspectorMounted = function() {
+    return !!document.getElementById(PPAS_SITE_INSPECTOR_IFRAME_ID);
+  }
+
   const listener = function(e) {
     let targets = [];
     let finalPath = '';
+
+    // don't collect data when in inspect mode
+    if (isSiteInspectorMounted()) {
+      document.removeEventListener('click', listener);
+      return;
+    }
 
     // handling missing method in IE11 / Edge
     if (!e.composedPath) {
@@ -71,7 +85,6 @@ export default (subscribe) => {
     subscribe(finalPath);
   };
 
-  // Listen on all clicks
   injectSevenTagConfiguration();
   document.addEventListener('click', listener);
 };

--- a/templates.js
+++ b/templates.js
@@ -154,17 +154,21 @@ window._paq.push(['trackEvent', 'UX Research', 'Excessive Scroll', lastKnownPosi
       id: 'heatmapClicks',
       name: 'Heatmap clicks collector',
       description: `
-      Exposed function allow to collect clicks data for Site Inspector's heatmap/clickmap feature.
-      Provided solution saves clicked target paths under custom event which name should remain unchanged to correct work of Site Inspector. 
+      Exposed function allow to collect clicks data for Site inspector's heatmap/clickmap feature.
+      Provided solution saves clicked target paths under custom event which name should remain unchanged to correct work of Site inspector. 
       `,
       template: `
 ${fs.readFileSync(path.join(__dirname, 'build/collectHeatmapClicks.js'), { encoding: 'utf-8' })}
 
 collectHeatmapClicks(function (targetPath) {
-   window._paq.push(['trackEvent', 'Heatmap events', 'Click', targetPath]);
+  window._paq.push(['trackEvent', 'Heatmap events', 'Click', targetPath]);
+}, {
+  interval: {{interval}},
 });
       `,
-      arguments: []
+      arguments: [
+        { id: 'interval', type: 'number', displayName: 'Time interval', description: 'Number of milliseconds to prevent click events spam', default: 100 },
+      ],
     },
   ]
 };


### PR DESCRIPTION
Fixed collecting classnames where there could be multiple whitespaces and we didn't handle that kind of separators. Added removing event listener when site inspector opens (to not collect clicks from overlays). Added confgurable listener throttling to prevent from click events spam.