### PR TITLE
fix: wrong event handling and lack of filter ability of unwanted classnames values

### DIFF
--- a/src/collectHeatmapClicks.js
+++ b/src/collectHeatmapClicks.js
@@ -16,6 +16,22 @@ export default (subscribe, { interval = 100 }) => {
     }
   };
 
+  const findClosestHref = function(element) {
+    while (element.parentNode) {
+      const parent = element.parentNode;
+
+      if (parent.href) {
+        return parent;
+      }
+    }
+
+    return null;
+  };
+
+  const performOnScriptEnd = function(fnc) {
+    setTimeout(fnc, 0);
+  };
+
   const getRawStringPath = function(steps) {
     let tag, stringSteps = [];
     for (let i = 0, element = steps[i]; element; element = element.parentNode, i++) {
@@ -96,9 +112,13 @@ export default (subscribe, { interval = 100 }) => {
           callback(finalPath);
           // handle default behaviour - redirect with delay (to perform tracking request)
           if (event.target.href) {
-            setTimeout(() => {
+            performOnScriptEnd(() => {
               window.location = event.target.href;
-            }, 0);
+            });
+          } else {
+            performOnScriptEnd(() => {
+              window.location = findClosestHref(event.target);
+            });
           }
           timer = null;
         }, interval); 

--- a/src/collectHeatmapClicks.js
+++ b/src/collectHeatmapClicks.js
@@ -1,4 +1,4 @@
-export default (subscribe, { interval = 100 }) => {
+export default (subscribe, { interval = 100, blacklistedClasses = [] }) => {
   const PPAS_SITE_INSPECTOR_IFRAME_ID = 'ppas_site_inspector';
   const PPAS_SITE_INSPECTOR_TAG_CONFIG_ID = 'ppas_container_configuration';
 
@@ -18,6 +18,15 @@ export default (subscribe, { interval = 100 }) => {
 
   const performOnScriptEnd = function(fnc) {
     setTimeout(fnc, 0);
+  };
+
+  const filterClasses = (classes) => {
+    let filteredClasses = classes;
+    blacklistedClasses.forEach(rule => {
+      filteredClasses = filteredClasses.replaceAll(rule, ' ');
+    });
+
+    return filteredClasses;
   };
 
   const getRawStringPath = function(steps) {
@@ -47,7 +56,11 @@ export default (subscribe, { interval = 100 }) => {
 
       // exclude SVGAnimatedString className objects
       if (typeof element.className === 'string' && element.className) {
-        const classes = element.className.replace(/\s+/g, '.');
+        let classes = element.className;
+        if (blacklistedClasses.length) {
+          classes = filterClasses(classes);
+        }
+        classes = classes.replace(/\s+/g, '.');
         tag += `.${classes}`;
       }
 
@@ -119,8 +132,9 @@ export default (subscribe, { interval = 100 }) => {
 
   injectSevenTagConfiguration();
 
+  // prevent event loop after resume event click
   const isEventReal = (event, callback) => {
-    if(event.screenX && event.screenX !== 0 && event.screenY && event.screenY !== 0) {
+    if (event.screenX && event.screenX !== 0 && event.screenY && event.screenY !== 0) {
       callback(event);
     }
   };

--- a/src/collectHeatmapClicks.js
+++ b/src/collectHeatmapClicks.js
@@ -23,7 +23,7 @@ export default (subscribe, { interval = 100, blacklistedClasses = [] }) => {
   const filterClasses = (classes) => {
     let filteredClasses = classes;
     blacklistedClasses.forEach(rule => {
-      filteredClasses = filteredClasses.replaceAll(rule, ' ');
+      filteredClasses = filteredClasses.replaceAll(rule, ' ').trim();
     });
 
     return filteredClasses;

--- a/src/collectHeatmapClicks.js
+++ b/src/collectHeatmapClicks.js
@@ -23,7 +23,7 @@ export default (subscribe, { interval = 100, blacklistedClasses = [] }) => {
   const filterClasses = (classes) => {
     let filteredClasses = classes;
     blacklistedClasses.forEach(rule => {
-      filteredClasses = filteredClasses.replaceAll(rule, ' ').trim();
+      filteredClasses = filteredClasses.replace(new RegExp(rule, 'g'), ' ').trim();
     });
 
     return filteredClasses;

--- a/templates.js
+++ b/templates.js
@@ -169,7 +169,7 @@ collectHeatmapClicks(function (targetPath) {
       `,
       arguments: [
         { id: 'interval', type: 'number', displayName: 'Time interval', description: 'Number of milliseconds to prevent click events spam', default: 100 },
-        { id: 'blacklistedClasses', type: 'text', displayName: 'Blacklisted classes', description: 'Array of strings of CSS classnames which will be filtered from final path', default: '[]' },
+        { id: 'blacklistedClasses', type: 'text', displayName: 'Blacklisted classes', description: 'Array of regexps (eg. /class-name/ for strict string search) of CSS classnames which will be filtered from final path', default: '[]' },
       ],
     },
     {

--- a/templates.js
+++ b/templates.js
@@ -162,9 +162,15 @@ ${fs.readFileSync(path.join(__dirname, 'build/collectHeatmapClicks.js'), { encod
 
 collectHeatmapClicks(function (targetPath) {
   window._paq.push(['trackEvent', 'Heatmap events', 'Click', targetPath]);
-}, {});
+}, {
+  interval: {{interval}},
+  blacklistedClasses: {{blacklistedClasses}},
+});
       `,
-      arguments: [],
+      arguments: [
+        { id: 'interval', type: 'number', displayName: 'Time interval', description: 'Number of milliseconds to prevent click events spam', default: 100 },
+        { id: 'blacklistedClasses', type: 'text', displayName: 'Blacklisted classes', description: 'Array of strings of CSS classnames which will be filtered from final path', default: '[]' },
+      ],
     },
     {
       id: 'formTimingTracking',


### PR DESCRIPTION
WHY:
 - we find out that handling only target's href is not enough
 - we find out cases where clients site has some omited by browser CSS engine characters like `||` (as a separators: `class="class1 || class2"`
 
 WHAT WAS DONE:
 - after we prevent default original event (because we need some time to calculate its path and perform request to tracker) we resume new click one and also prevent before making loop
 - we exposed configurable array of regexp parameters where we can filter them during path creation (like `||` or any other custom, there is no stadarization about `class` possible values) 