### PR TITLE
'Click' as custom event action, move path to name

### DIFF
--- a/templates.js
+++ b/templates.js
@@ -169,6 +169,7 @@ ${fs.readFileSync(path.join(__dirname, 'build/collectHeatmapClicks.js'), { encod
     window._paq.push([
       'trackEvent',
       'Heatmap events',
+      'Click',
       heatmapCollector.getElementPath(
         e,
         { blacklistedClasses: {{blacklistedClasses}} },


### PR DESCRIPTION
Fix because of missing custom event action placeholder value in previous version. 'Click' should be event action, and the path should be event name.