### PR TITLE
fix: quickback script wrong output for custom event (object instead of url string)

### DIFF
--- a/src/detectQuickBacks.js
+++ b/src/detectQuickBacks.js
@@ -17,9 +17,9 @@ export default (subscribe, { threshold = 12000 }) => {
 
   if (hasQuickBack) {
     const currentStateIndex = state.map(entry => entry.value).lastIndexOf(url);
-    const data = { target: state[currentStateIndex - 1].value };
+    const target = state[currentStateIndex - 1].value;
 
-    subscribe(data);
+    subscribe(target);
   }
 
   document.addEventListener('click', listener);


### PR DESCRIPTION
Ticket: https://piwikpro.atlassian.net/browse/PPCDEV-14294
Working code for tests/use:
```
(function () {
var detectQuickBacks;detectQuickBacks=function(){"use strict";var e={853:function(e,t,n){var r=this&&this.__importDefault||function(e){return e&&e.__esModule?e:{default:e}};Object.defineProperty(t,"__esModule",{value:!0});var u=r(n(338)),o=r(n(22)),i="__pp_detect_quick_backs";t.default=function(e,t){var n=t.threshold,r=void 0===n?12e3:n,a=(new Date).getTime(),f=document.location.href,l=u.default(i,f,a-r),c=l.filter((function(e){return e.value===f})).length>1,d=function(e){e.target.href&&o.default(e.target.href)&&u.default(i,e.target.href,a-r)};if(c){var s=l.map((function(e){return e.value})).lastIndexOf(f);e(l[s-1].value)}return document.addEventListener("click",d),function(){removeEventListener("click",d)}}},338:function(e,t,n){var r=this&&this.__importDefault||function(e){return e&&e.__esModule?e:{default:e}};Object.defineProperty(t,"__esModule",{value:!0});var u=r(n(912)),o=r(n(638));t.default=function(e,t,n){var r,i=(null!==(r=u.default(e))&&void 0!==r?r:[]).filter((function(e){return e.time>n}));return i.push({value:t,time:(new Date).getTime()}),o.default(e,i),i}},912:function(e,t){Object.defineProperty(t,"__esModule",{value:!0}),t.default=function(e){var t=sessionStorage.getItem(e);return t&&JSON.parse(t)}},22:function(e,t){Object.defineProperty(t,"__esModule",{value:!0}),t.default=function(e){return-1===e.indexOf(location.protocol+"//"+location.host)}},638:function(e,t){Object.defineProperty(t,"__esModule",{value:!0}),t.default=function(e,t){sessionStorage.setItem(e,JSON.stringify(t))}}},t={};return function n(r){if(t[r])return t[r].exports;var u=t[r]={exports:{}};return e[r].call(u.exports,u,u.exports,n),u.exports}(853)}().default;

var unsubscribe = detectQuickBacks(function (url) {
window._paq.push(['trackEvent', 'UX Research', 'Quick Back', url]);

// unsubscribe(); // Uncomment this line when you want to finish after first trigger
}, {
  threshold: 12000,
});      
      })();