### PR TITLE
Pprevops 779 implement universal solution to templates where possible

### DIFF
--- a/src/videoTrackingHTML5.js
+++ b/src/videoTrackingHTML5.js
@@ -265,7 +265,7 @@
     }
     
     let mediaElements = document.querySelectorAll(videoElementSelector);
-    if (mediaElements[0] != null && mediaElements[0] != undefined) {
+    if (mediaElements.length) {
         addListenersForEachItem(mediaElements);
     } else {
         waitForElement(videoElementSelector).then(function(){

--- a/src/videoTrackingHTML5.js
+++ b/src/videoTrackingHTML5.js
@@ -3,7 +3,7 @@
  * 
  * This script analyses the interactions with <video> elements.
  */
- export default ({eventCategoryLabel,
+ export default (subscribe,{eventCategoryLabel,
     videoElementSelector,
     videoTitleAttribute,
     trackingAccuracy,
@@ -55,7 +55,7 @@
                 }
                 eventArray.push(dimensionsObject);
             }
-            window._paq.push(eventArray);
+            subscribe(eventArray);
     };
 
     const processPlayMediaEvent = (e) => {

--- a/templates.js
+++ b/templates.js
@@ -251,7 +251,10 @@ window._paq.push(["trackEvent","User interaction","Copying text",copiedItemText]
     `,
     template: `
 ${fs.readFileSync(path.join(__dirname, 'build/videoTrackingHTML5.js'), { encoding: 'utf-8' })}
-videoTrackingHTML5({
+
+videoTrackingHTML5(function(eventData) {
+  window._paq.push(eventData);
+}, {
   videoElementSelector: '{{videoElementSelector}}',
   eventCategoryLabel: '{{eventCategoryLabel}}',
   videoTitleAttribute: '{{videoTitleAttribute}}',


### PR DESCRIPTION
Added a wait for element solution to the video tracking to make sure it will add the listeners in every case (Even if it is a delayed video). I also changed the _paq.push to be outside of the function. 

The comparison of the previous version and the new version can be seen here - 
**New:** https://multiwp.demopiwikpro.com/kbigos/delayed-video/
**Old:** https://multiwp.demopiwikpro.com/kbigos/delayed-video-old-template/

You should see events being tracked on the new template