### PR TITLE
Pprevops 813 implement iframe tracking to templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "workspaces": [
     "docs",
     "src",
-    "src/helpers"
+    "src/helpers",
+    "src/helpers/minified"
   ],
   "repository": "https://github.com/PiwikPRO/solutions-templates",
   "scripts": {

--- a/src/detectDeadClicks.js
+++ b/src/detectDeadClicks.js
@@ -9,7 +9,7 @@ import getSelectorFromTarget from 'helpers/getSelectorFromTarget';
  * but to no avail. In such situations, the visitor will end up clicking twice, quickly.
  * Looking for dead clicks will help you find these main points of frustration and improve visitors` experience as soon as possible.
  */
-export default (subscribe, { interval, limit, iframeTracking }) => {
+export default (subscribe, { interval, limit }) => {
   let clickCounts = {};
 
   // Clear state when reach time limit
@@ -24,12 +24,7 @@ export default (subscribe, { interval, limit, iframeTracking }) => {
 
     if (clickCounts[selector] === limit) {
       var eventData = ['trackEvent', 'UX Research', 'Dead Click', selector];
-      if(iframeTracking){
-        window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*"); 
-      }
-      else{
-        subscribe(eventData);
-      }
+      subscribe(eventData);
     }
   };
 

--- a/src/detectDeadClicks.js
+++ b/src/detectDeadClicks.js
@@ -9,7 +9,7 @@ import getSelectorFromTarget from 'helpers/getSelectorFromTarget';
  * but to no avail. In such situations, the visitor will end up clicking twice, quickly.
  * Looking for dead clicks will help you find these main points of frustration and improve visitors` experience as soon as possible.
  */
-export default (subscribe, { interval, limit }) => {
+export default (subscribe, { interval, limit, iframeTracking }) => {
   let clickCounts = {};
 
   // Clear state when reach time limit
@@ -23,7 +23,13 @@ export default (subscribe, { interval, limit }) => {
     clickCounts[selector] = clickCounts[selector] ? clickCounts[selector] + 1 : 1;
 
     if (clickCounts[selector] === limit) {
-      subscribe(selector);
+      var eventData = ['trackEvent', 'UX Research', 'Dead Click', selector];
+      if(iframeTracking){
+        window.parent.postMessage(eventData, "*"); 
+      }
+      else{
+        subscribe(eventData);
+      }
     }
   };
 

--- a/src/detectDeadClicks.js
+++ b/src/detectDeadClicks.js
@@ -25,7 +25,7 @@ export default (subscribe, { interval, limit, iframeTracking }) => {
     if (clickCounts[selector] === limit) {
       var eventData = ['trackEvent', 'UX Research', 'Dead Click', selector];
       if(iframeTracking){
-        window.parent.postMessage(eventData, "*"); 
+        window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*"); 
       }
       else{
         subscribe(eventData);

--- a/src/detectErrorClicks.js
+++ b/src/detectErrorClicks.js
@@ -9,7 +9,7 @@ import getSelectorFromTarget from 'helpers/getSelectorFromTarget';
  * Often the visitor doesn’t notice that something is broken, but for you,
  * it’s a signal that a particular JavaScript element is not working.
  */
-export default (subscribe) => {
+export default (subscribe, { iframeTracking }) => {
   let error;
 
   window.onerror = (msg) => {
@@ -21,7 +21,13 @@ export default (subscribe) => {
 
     setTimeout(() => {
       if (error) {
-        subscribe(selector, error);
+        var eventData = ['trackEvent', 'UX Research', 'Error Click', selector];
+        if(iframeTracking){
+          window.parent.postMessage(eventData, "*"); 
+        }
+        else{
+          subscribe(eventData);
+        }
       }
 
       error = undefined;

--- a/src/detectErrorClicks.js
+++ b/src/detectErrorClicks.js
@@ -23,7 +23,7 @@ export default (subscribe, { iframeTracking }) => {
       if (error) {
         var eventData = ['trackEvent', 'UX Research', 'Error Click', selector];
         if(iframeTracking){
-          window.parent.postMessage(eventData, "*"); 
+          window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*"); 
         }
         else{
           subscribe(eventData);

--- a/src/detectErrorClicks.js
+++ b/src/detectErrorClicks.js
@@ -9,7 +9,7 @@ import getSelectorFromTarget from 'helpers/getSelectorFromTarget';
  * Often the visitor doesn’t notice that something is broken, but for you,
  * it’s a signal that a particular JavaScript element is not working.
  */
-export default (subscribe, { iframeTracking }) => {
+export default (subscribe) => {
   let error;
 
   window.onerror = (msg) => {
@@ -22,12 +22,8 @@ export default (subscribe, { iframeTracking }) => {
     setTimeout(() => {
       if (error) {
         var eventData = ['trackEvent', 'UX Research', 'Error Click', selector];
-        if(iframeTracking){
-          window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*"); 
-        }
-        else{
-          subscribe(eventData);
-        }
+        subscribe(eventData);
+        
       }
 
       error = undefined;

--- a/src/detectMouseShake.js
+++ b/src/detectMouseShake.js
@@ -48,7 +48,7 @@ export default (subscribe, { interval, threshold, iframeTracking }) => {
     if (directionChangeCount && acceleration > threshold) {
       var eventData = ['trackEvent', 'UX Research', 'Mouse shake'];
       if(iframeTracking){
-        window.parent.postMessage(eventData, "*");      
+        window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*");      
       }
       else{
         subscribe();

--- a/src/detectMouseShake.js
+++ b/src/detectMouseShake.js
@@ -16,7 +16,7 @@
  *   threshold: 0.01, // Acceleration of mouse movement threshold
  * });
  */
-export default (subscribe, { interval, threshold, iframeTracking }) => {
+export default (subscribe, { interval, threshold }) => {
   let velocity;
   let direction;
   let directionChangeCount = 0;
@@ -46,13 +46,8 @@ export default (subscribe, { interval, threshold, iframeTracking }) => {
     const acceleration = (nextVelocity - velocity) / interval;
 
     if (directionChangeCount && acceleration > threshold) {
-      var eventData = ['trackEvent', 'UX Research', 'Mouse shake'];
-      if(iframeTracking){
-        window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*");      
-      }
-      else{
-        subscribe();
-      }
+      let eventData = ['trackEvent', 'UX Research', 'Mouse shake'];
+      subscribe(eventData); 
     }
 
     distance = 0;

--- a/src/detectMouseShake.js
+++ b/src/detectMouseShake.js
@@ -16,7 +16,7 @@
  *   threshold: 0.01, // Acceleration of mouse movement threshold
  * });
  */
-export default (subscribe, { interval, threshold }) => {
+export default (subscribe, { interval, threshold, iframeTracking }) => {
   let velocity;
   let direction;
   let directionChangeCount = 0;
@@ -46,7 +46,13 @@ export default (subscribe, { interval, threshold }) => {
     const acceleration = (nextVelocity - velocity) / interval;
 
     if (directionChangeCount && acceleration > threshold) {
-      subscribe();
+      var eventData = ['trackEvent', 'UX Research', 'Mouse shake'];
+      if(iframeTracking){
+        window.parent.postMessage(eventData, "*");      
+      }
+      else{
+        subscribe();
+      }
     }
 
     distance = 0;

--- a/src/detectQuickBacks.js
+++ b/src/detectQuickBacks.js
@@ -24,7 +24,7 @@ export default (subscribe, { threshold = 12000 }) => {
 
   document.addEventListener('click', listener);
 
- /* return () => {
+  return () => {
     removeEventListener('click', listener);
-  };*/
+  }; 
 };

--- a/src/detectQuickBacks.js
+++ b/src/detectQuickBacks.js
@@ -24,7 +24,7 @@ export default (subscribe, { threshold = 12000 }) => {
 
   document.addEventListener('click', listener);
 
-  return () => {
+ /* return () => {
     removeEventListener('click', listener);
-  };
+  };*/
 };

--- a/src/detectRageClicks.js
+++ b/src/detectRageClicks.js
@@ -8,7 +8,7 @@ import getSelectorFromTarget from 'helpers/getSelectorFromTarget';
  * In most cases, rage clicks signal that your website didn’t react the way your visitor expected,
  * so you may want to take a closer look at it.
  */
-export default (subscribe, { interval, limit }) => {
+export default (subscribe, { interval, limit, iframeTracking }) => {
   let count = 1;
 
   // Clear state when reach time limit
@@ -18,7 +18,14 @@ export default (subscribe, { interval, limit }) => {
 
   const listener = (event) => {
     if (count === limit) {
-      subscribe(getSelectorFromTarget(event.target));
+      var eventData = ['trackEvent', 'UX Research', 'Rage click', getSelectorFromTarget(event.target)];
+      if(iframeTracking)
+      {
+        window.parent.postMessage(eventData, "*");
+      }
+      else{
+        subscribe(eventData);
+      }
     }
 
     count++;

--- a/src/detectRageClicks.js
+++ b/src/detectRageClicks.js
@@ -21,7 +21,7 @@ export default (subscribe, { interval, limit, iframeTracking }) => {
       var eventData = ['trackEvent', 'UX Research', 'Rage click', getSelectorFromTarget(event.target)];
       if(iframeTracking)
       {
-        window.parent.postMessage(eventData, "*");
+        window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*");
       }
       else{
         subscribe(eventData);

--- a/src/detectRageClicks.js
+++ b/src/detectRageClicks.js
@@ -8,7 +8,7 @@ import getSelectorFromTarget from 'helpers/getSelectorFromTarget';
  * In most cases, rage clicks signal that your website didn’t react the way your visitor expected,
  * so you may want to take a closer look at it.
  */
-export default (subscribe, { interval, limit, iframeTracking }) => {
+export default (subscribe, { interval, limit }) => {
   let count = 1;
 
   // Clear state when reach time limit
@@ -19,13 +19,7 @@ export default (subscribe, { interval, limit, iframeTracking }) => {
   const listener = (event) => {
     if (count === limit) {
       var eventData = ['trackEvent', 'UX Research', 'Rage click', getSelectorFromTarget(event.target)];
-      if(iframeTracking)
-      {
-        window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*");
-      }
-      else{
-        subscribe(eventData);
-      }
+      subscribe(eventData);
     }
 
     count++;

--- a/src/formTimingTracking.js
+++ b/src/formTimingTracking.js
@@ -17,7 +17,7 @@
         let interactionType = "Submit";
         var eventData = ['trackEvent', eventCategoryPrefix+formName, fieldName, interactionType, 0];
         if(iframeTracking){
-            window.parent.postMessage(eventData, "*");
+            window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*");
         }
         else{
             subscribe(eventData); 
@@ -39,7 +39,7 @@
             if (timeSpent > 0 && timeSpent < 1800000) {
                 var eventData = ['trackEvent', eventCategoryPrefix+formName, fieldName, interactionType, timeSpent/1000 || 0 ];
                 if(iframeTracking){
-                    window.parent.postMessage(eventData, "*");
+                    window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*");
                 }
                 else{
                     subscribe(eventData);

--- a/src/formTimingTracking.js
+++ b/src/formTimingTracking.js
@@ -4,7 +4,7 @@
  * This script analyses the interactions with <form> fields.
  */
 
- export default (subscribe, {formNameAttribute, fieldNameAttribute, eventCategoryPrefix, iframeTracking}) => {
+ export default (subscribe, {formNameAttribute, fieldNameAttribute, eventCategoryPrefix}) => {
     let fieldsTimings = {};
 
     const getFieldName = (field) => field.getAttribute(fieldNameAttribute);
@@ -16,12 +16,7 @@
         let fieldName = "Click";
         let interactionType = "Submit";
         var eventData = ['trackEvent', eventCategoryPrefix+formName, fieldName, interactionType, 0];
-        if(iframeTracking){
-            window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*");
-        }
-        else{
-            subscribe(eventData); 
-        } 
+        subscribe(eventData); 
     };
 
     const trackFormFieldEntry = (e) => {
@@ -38,13 +33,7 @@
             let timeSpent = new Date().getTime() - fieldsTimings[fieldName];
             if (timeSpent > 0 && timeSpent < 1800000) {
                 var eventData = ['trackEvent', eventCategoryPrefix+formName, fieldName, interactionType, timeSpent/1000 || 0 ];
-                if(iframeTracking){
-                    window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*");
-                }
-                else{
-                    subscribe(eventData);
-                }
-
+                subscribe(eventData);
             }
             delete fieldsTimings[fieldName];
         }

--- a/src/formTimingTracking.js
+++ b/src/formTimingTracking.js
@@ -4,7 +4,7 @@
  * This script analyses the interactions with <form> fields.
  */
 
- export default (subscribe, {formNameAttribute, fieldNameAttribute}) => {
+ export default (subscribe, {formNameAttribute, fieldNameAttribute, eventCategoryPrefix, iframeTracking}) => {
     let fieldsTimings = {};
 
     const getFieldName = (field) => field.getAttribute(fieldNameAttribute);
@@ -15,7 +15,13 @@
         let formName = getFormName(e.target);
         let fieldName = "Click";
         let interactionType = "Submit";
-        subscribe({ formName, fieldName, interactionType });  
+        var eventData = ['trackEvent', eventCategoryPrefix+formName, fieldName, interactionType, 0];
+        if(iframeTracking){
+            window.parent.postMessage(eventData, "*");
+        }
+        else{
+            subscribe(eventData); 
+        } 
     };
 
     const trackFormFieldEntry = (e) => {
@@ -31,7 +37,14 @@
         if (fieldsTimings.hasOwnProperty(fieldName)) {
             let timeSpent = new Date().getTime() - fieldsTimings[fieldName];
             if (timeSpent > 0 && timeSpent < 1800000) {
-                subscribe({ formName, fieldName, interactionType, timeSpent });
+                var eventData = ['trackEvent', eventCategoryPrefix+formName, fieldName, interactionType, timeSpent/1000 || 0 ];
+                if(iframeTracking){
+                    window.parent.postMessage(eventData, "*");
+                }
+                else{
+                    subscribe(eventData);
+                }
+
             }
             delete fieldsTimings[fieldName];
         }

--- a/src/helpers/minified/package.json
+++ b/src/helpers/minified/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "minified-helpers"
+}

--- a/src/helpers/minified/postIframeMessage.js
+++ b/src/helpers/minified/postIframeMessage.js
@@ -1,0 +1,3 @@
+export default (payload) => {
+    window.parent.postMessage({ type: 'PiwikPRO', payload }, '*');
+  };

--- a/src/helpers/minified/pushToAnalytics.js
+++ b/src/helpers/minified/pushToAnalytics.js
@@ -1,0 +1,3 @@
+export default (payload) => {
+    window._paq.push(payload);
+  };

--- a/src/trackCopiedText.js
+++ b/src/trackCopiedText.js
@@ -12,7 +12,7 @@
 
         if(iframeTracking)
         {
-            window.parent.postMessage(eventData, "*");
+            window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*");
         }
         else{
             subscribe(eventData);   

--- a/src/trackCopiedText.js
+++ b/src/trackCopiedText.js
@@ -4,11 +4,20 @@
  * Adds event listener that monitors all copy events and sends text copied at the time as custom event.
  */
 
- export default (subscribe) => {
+ export default (subscribe,{iframeTracking}) => {
     
     const processCopyEvent = () => {
         let copiedItemText = getSelectedText();
-        subscribe(copiedItemText);
+        var eventData = ["trackEvent","User interaction","Copying text",copiedItemText];
+
+        if(iframeTracking)
+        {
+            window.parent.postMessage(eventData, "*");
+        }
+        else{
+            subscribe(eventData);   
+        }
+
     };
     
     const getSelectedText = () => window.getSelection()?.toString() ?? '';

--- a/src/trackCopiedText.js
+++ b/src/trackCopiedText.js
@@ -4,20 +4,12 @@
  * Adds event listener that monitors all copy events and sends text copied at the time as custom event.
  */
 
- export default (subscribe,{iframeTracking}) => {
+ export default (subscribe) => {
     
     const processCopyEvent = () => {
         let copiedItemText = getSelectedText();
         var eventData = ["trackEvent","User interaction","Copying text",copiedItemText];
-
-        if(iframeTracking)
-        {
-            window.parent.postMessage({type: "PiwikPRO", payload: eventData}, "*");
-        }
-        else{
-            subscribe(eventData);   
-        }
-
+        subscribe(eventData);   
     };
     
     const getSelectedText = () => window.getSelection()?.toString() ?? '';

--- a/src/videoTrackingHTML5.js
+++ b/src/videoTrackingHTML5.js
@@ -12,8 +12,7 @@
     trackTimestampAsDimension,
     dimensionIdForTimestamps,
     trackVolumeAsDimension,
-    dimensionIdForVolume,
-    iframeTracking
+    dimensionIdForVolume
 
 }) => {
     
@@ -57,14 +56,7 @@
                 }
                 eventArray.push(dimensionsObject);
             }
-
-            if(iframeTracking)
-            {
-                window.parent.postMessage({type: "PiwikPRO", payload: eventArray}, "*");
-            }
-            else{
-                subscribe(eventArray);
-            }
+            subscribe(eventArray);
     };
 
     const processPlayMediaEvent = (e) => {
@@ -274,7 +266,7 @@
     }
     
     let mediaElements = document.querySelectorAll(videoElementSelector);
-    if (mediaElements[0] != null && mediaElements[0] != undefined) {
+    if (mediaElements.length) {
         addListenersForEachItem(mediaElements);
     } else {
         waitForElement(videoElementSelector).then(function(){

--- a/src/videoTrackingHTML5.js
+++ b/src/videoTrackingHTML5.js
@@ -3,7 +3,7 @@
  * 
  * This script analyses the interactions with <video> elements.
  */
- export default ({eventCategoryLabel,
+ export default (subscribe,{eventCategoryLabel,
     videoElementSelector,
     videoTitleAttribute,
     trackingAccuracy,
@@ -55,7 +55,7 @@
                 }
                 eventArray.push(dimensionsObject);
             }
-            window._paq.push(eventArray);
+            subscribe(eventArray);
     };
 
     const processPlayMediaEvent = (e) => {

--- a/src/videoTrackingHTML5.js
+++ b/src/videoTrackingHTML5.js
@@ -12,7 +12,9 @@
     trackTimestampAsDimension,
     dimensionIdForTimestamps,
     trackVolumeAsDimension,
-    dimensionIdForVolume
+    dimensionIdForVolume,
+    iframeTracking
+
 }) => {
     
     const percentageThresholds = thresholdsToTrack.split(",").map(x=>+x);
@@ -55,7 +57,14 @@
                 }
                 eventArray.push(dimensionsObject);
             }
-            subscribe(eventArray);
+
+            if(iframeTracking)
+            {
+                window.parent.postMessage(eventArray, "*");
+            }
+            else{
+                subscribe(eventArray);
+            }
     };
 
     const processPlayMediaEvent = (e) => {

--- a/src/videoTrackingHTML5.js
+++ b/src/videoTrackingHTML5.js
@@ -60,7 +60,7 @@
 
             if(iframeTracking)
             {
-                window.parent.postMessage(eventArray, "*");
+                window.parent.postMessage({type: "PiwikPRO", payload: eventArray}, "*");
             }
             else{
                 subscribe(eventArray);

--- a/templates.js
+++ b/templates.js
@@ -436,12 +436,13 @@ videoTrackingHTML5(function(eventData) {
       sent from the iframe on the parent website and turn them into events.
     `,
     template: `
-    window.addEventListener('message', function(event){ 
-      if(event.data.type === "PiwikPRO")
-      {
-       _paq.push(event.data.payload); 
-      }
-     }, false);  
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}   
+
+window.addEventListener('message', function(event){ 
+  if(event.data.type === "PiwikPRO"){
+    pushToAnalytics(event.data.payload); 
+  }
+}, false);  
     `,
     arguments: [        
    ]

--- a/templates.js
+++ b/templates.js
@@ -251,7 +251,10 @@ window._paq.push(["trackEvent","User interaction","Copying text",copiedItemText]
     `,
     template: `
 ${fs.readFileSync(path.join(__dirname, 'build/videoTrackingHTML5.js'), { encoding: 'utf-8' })}
-videoTrackingHTML5({
+
+videoTrackingHTML5(function(eventData) {
+  window._paq.push(eventData);
+}, {
   videoElementSelector: '{{videoElementSelector}}',
   eventCategoryLabel: '{{eventCategoryLabel}}',
   videoTitleAttribute: '{{videoTitleAttribute}}',

--- a/templates.js
+++ b/templates.js
@@ -19,16 +19,22 @@ module.exports = {
       Looking for dead clicks will help you find these main points of frustration and improve visitors\` experience as soon as possible.
       `,
       template: `
+${fs.readFileSync(path.join(__dirname, 'build/postIframeMessage.js'), { encoding: 'utf-8' })}    
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}       
 ${fs.readFileSync(path.join(__dirname, 'build/detectDeadClicks.js'), { encoding: 'utf-8' })}
 
 var unsubscribe = detectDeadClicks(function (eventData) {
-window._paq.push(eventData);
+  var trackFromIframe = {{iframeTracking}}; 
+  if(!trackFromIframe){
+    pushToAnalytics(eventData);
+  } else {
+    postIframeMessage(eventData);
+  }
 
 // unsubscribe();
 }, {
 interval: {{interval}},
 limit: {{limit}},
-iframeTracking: {{iframeTracking}},
 });
       `,
       arguments: [
@@ -53,14 +59,18 @@ iframeTracking: {{iframeTracking}},
         it’s a signal that a particular JavaScript element is not working.
       `,
       template: `
+${fs.readFileSync(path.join(__dirname, 'build/postIframeMessage.js'), { encoding: 'utf-8' })}    
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}         
 ${fs.readFileSync(path.join(__dirname, 'build/detectErrorClicks.js'), { encoding: 'utf-8' })}
 
 var unsubscribe = detectErrorClicks(function (eventData) {
-window._paq.push(eventData);
-
+  var trackFromIframe = {{iframeTracking}}; 
+  if(!trackFromIframe){
+    pushToAnalytics(eventData);
+  } else {
+    postIframeMessage(eventData);
+  }
 // unsubscribe(); // Uncomment this line when you want to finish after first trigger
-}, {
-iframeTracking: {{iframeTracking}},
 });
       `,
       arguments: [        
@@ -81,16 +91,22 @@ iframeTracking: {{iframeTracking}},
         Perhaps the site performance is slow or they are struggling to figure something out.
       `,
       template: `
+${fs.readFileSync(path.join(__dirname, 'build/postIframeMessage.js'), { encoding: 'utf-8' })}    
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}          
 ${fs.readFileSync(path.join(__dirname, 'build/detectMouseShake.js'), { encoding: 'utf-8' })}
 
-var unsubscribe = detectMouseShake(function () {
-window._paq.push(['trackEvent', 'UX Research', 'Mouse shake']);
+var unsubscribe = detectMouseShake(function (eventData) {
+  var trackFromIframe = {{iframeTracking}}; 
+  if(!trackFromIframe){
+    pushToAnalytics(eventData);
+  } else {
+    postIframeMessage(eventData);
+  }
 
 // unsubscribe(); // Uncomment this line when you want to finish after first trigger
 }, {
 interval: {{interval}},
 threshold: {{threshold}},
-iframeTracking: {{iframeTracking}},
 });
       `,
       arguments: [
@@ -114,16 +130,22 @@ iframeTracking: {{iframeTracking}},
         so you may want to take a closer look at it.
       `,
       template: `
+${fs.readFileSync(path.join(__dirname, 'build/postIframeMessage.js'), { encoding: 'utf-8' })}    
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}         
 ${fs.readFileSync(path.join(__dirname, 'build/detectRageClicks.js'), { encoding: 'utf-8' })}
 
 var unsubscribe = detectRageClicks(function (eventData) {
-window._paq.push(eventData);
+  var trackFromIframe = {{iframeTracking}}; 
+  if(!trackFromIframe){
+    pushToAnalytics(eventData);
+  } else {
+    postIframeMessage(eventData);
+  }
 
 // unsubscribe(); // Uncomment this line when you want to finish after first trigger
 }, {
 interval: {{interval}},
 limit: {{limit}},
-iframeTracking: {{iframeTracking}},
 });
       `,
       arguments: [
@@ -145,10 +167,11 @@ iframeTracking: {{iframeTracking}},
         which the user does not find useful and returns to the original page or website under a certain threshold of time.
       `,
       template: `
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}       
 ${fs.readFileSync(path.join(__dirname, 'build/detectQuickBacks.js'), { encoding: 'utf-8' })}
 
 var unsubscribe = detectQuickBacks(function (url) {
-window._paq.push(['trackEvent', 'UX Research', 'Quick Back', url]);
+  pushToAnalytics(['trackEvent', 'UX Research', 'Quick Back', url]);
 
 // unsubscribe(); // Uncomment this line when you want to finish after first trigger
 }, {
@@ -166,10 +189,11 @@ window._paq.push(['trackEvent', 'UX Research', 'Quick Back', url]);
         Excessive scrolling detects when a user scrolls through site content at a higher rate than expected for standard content consumption.
       `,
       template: `
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}           
 ${fs.readFileSync(path.join(__dirname, 'build/detectExcessiveScroll.js'), { encoding: 'utf-8' })}
 
 var unsubscribe = detectExcessiveScroll(function (lastKnownPosition) {
-window._paq.push(['trackEvent', 'UX Research', 'Excessive Scroll', lastKnownPosition]);
+  pushToAnalytics(['trackEvent', 'UX Research', 'Excessive Scroll', lastKnownPosition]);
 
 // unsubscribe(); // Uncomment this line when you want to finish after first trigger
 }, {
@@ -189,13 +213,14 @@ window._paq.push(['trackEvent', 'UX Research', 'Excessive Scroll', lastKnownPosi
       Provided solution saves clicked target paths under custom event which name should remain unchanged to correct work of Site inspector.
       `,
       template: `
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}          
 ${fs.readFileSync(path.join(__dirname, 'build/collectHeatmapClicks.js'), { encoding: 'utf-8' })}
   var heatmapCollector = collectHeatmapClicks();
 
   heatmapCollector.injectConfigForSiteInspector();
 
   document.addEventListener('click', function(e) {
-    window._paq.push([
+    pushToAnalytics([
       'trackEvent',
       'Heatmap events',
       'Click',
@@ -272,12 +297,17 @@ formTimingTracking(function (eventData) {
     This template allows you to track pieces of text that are copied to clipboard by your website users.
     `,
     template: `
+${fs.readFileSync(path.join(__dirname, 'build/postIframeMessage.js'), { encoding: 'utf-8' })}    
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}        
 ${fs.readFileSync(path.join(__dirname, 'build/trackCopiedText.js'), { encoding: 'utf-8' })}
 
 trackCopiedText(function (eventData) {
-    window._paq.push(eventData);
-}, {
-  iframeTracking: {{iframeTracking}},
+  var trackFromIframe = {{iframeTracking}}; 
+  if(!trackFromIframe){
+    pushToAnalytics(eventData);
+  } else {
+    postIframeMessage(eventData);
+  }
 });
     `,
     arguments: [

--- a/templates.js
+++ b/templates.js
@@ -193,13 +193,8 @@ ${fs.readFileSync(path.join(__dirname, 'build/collectHeatmapClicks.js'), { encod
 ${fs.readFileSync(path.join(__dirname, 'build/formTimingTracking.js'), { encoding: 'utf-8' })}
 
 formTimingTracking(function (fieldInteractionData) {
-  window._paq.push([
-                  'trackEvent',
-                  '{{eventCategoryPrefix}}'+fieldInteractionData.formName,
-                  fieldInteractionData.fieldName,
-                  fieldInteractionData.interactionType,
-                  fieldInteractionData.timeSpent/1000 || 0
-                  ])
+  var eventData = ['trackEvent', '{{eventCategoryPrefix}}'+fieldInteractionData.formName, fieldInteractionData.fieldName, fieldInteractionData.interactionType, fieldInteractionData.timeSpent/1000 || 0 ]
+    window._paq.push(eventData)
 }, {
   formNameAttribute: '{{formNameAttribute}}',
   fieldNameAttribute: '{{fieldNameAttribute}}',
@@ -238,10 +233,12 @@ formTimingTracking(function (fieldInteractionData) {
 ${fs.readFileSync(path.join(__dirname, 'build/trackCopiedText.js'), { encoding: 'utf-8' })}
 
 trackCopiedText(function (copiedItemText) {
-window._paq.push(["trackEvent","User interaction","Copying text",copiedItemText]);
+  var eventData = ["trackEvent","User interaction","Copying text",copiedItemText]
+    window._paq.push(eventData);
 }, {});
     `,
-    arguments: [],
+    arguments: [      
+   ],
   },
   {
     id: 'videoTrackingHTML5',
@@ -253,7 +250,7 @@ window._paq.push(["trackEvent","User interaction","Copying text",copiedItemText]
 ${fs.readFileSync(path.join(__dirname, 'build/videoTrackingHTML5.js'), { encoding: 'utf-8' })}
 
 videoTrackingHTML5(function(eventData) {
-  window._paq.push(eventData);
+    window._paq.push(eventData);
 }, {
   videoElementSelector: '{{videoElementSelector}}',
   eventCategoryLabel: '{{eventCategoryLabel}}',
@@ -264,7 +261,8 @@ videoTrackingHTML5(function(eventData) {
   trackTimestampAsDimension: {{trackTimestampAsDimension}},
   dimensionIdForTimestamps: '{{dimensionIdForTimestamps}}',
   trackVolumeAsDimension: {{trackVolumeAsDimension}},
-  dimensionIdForVolume: '{{dimensionIdForVolume}}'
+  dimensionIdForVolume: '{{dimensionIdForVolume}}',
+  iframeTracking: {{iframeTracking}},
 });
     `,
     arguments: [
@@ -334,6 +332,12 @@ videoTrackingHTML5(function(eventData) {
         displayName: 'Custom dimension ID for storing volume level',
         description: 'If you track volume level as a custom dimension, create a custom dimension under Analytics > Settings > Custom dimensions and enter the dimension ID here.',
         default: 1
+      },
+      { id: 'iframeTracking',
+      type: 'boolean',
+      displayName: 'Send messages from iframes',
+      description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+      default: false
       },
     ],
   },

--- a/templates.js
+++ b/templates.js
@@ -296,10 +296,17 @@ trackCopiedText(function (eventData) {
     This template allows you to track videos watched on your website
     `,
     template: `
+${fs.readFileSync(path.join(__dirname, 'build/postIframeMessage.js'), { encoding: 'utf-8' })}    
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}        
 ${fs.readFileSync(path.join(__dirname, 'build/videoTrackingHTML5.js'), { encoding: 'utf-8' })}
 
 videoTrackingHTML5(function(eventData) {
-    window._paq.push(eventData);
+  var trackFromIframe = {{iframeTracking}}; 
+  if(!trackFromIframe){
+    pushToAnalytics(eventData);
+  } else {
+    postIframeMessage(eventData);
+  }
 }, {
   videoElementSelector: '{{videoElementSelector}}',
   eventCategoryLabel: '{{eventCategoryLabel}}',
@@ -311,7 +318,6 @@ videoTrackingHTML5(function(eventData) {
   dimensionIdForTimestamps: '{{dimensionIdForTimestamps}}',
   trackVolumeAsDimension: {{trackVolumeAsDimension}},
   dimensionIdForVolume: '{{dimensionIdForVolume}}',
-  iframeTracking: {{iframeTracking}},
 });
     `,
     arguments: [

--- a/templates.js
+++ b/templates.js
@@ -219,15 +219,21 @@ ${fs.readFileSync(path.join(__dirname, 'build/collectHeatmapClicks.js'), { encod
         <form> element on your website will be automatically detected. It will also track the submission of the form.
       `,
       template: `
+${fs.readFileSync(path.join(__dirname, 'build/postIframeMessage.js'), { encoding: 'utf-8' })}    
+${fs.readFileSync(path.join(__dirname, 'build/pushToAnalytics.js'), { encoding: 'utf-8' })}    
 ${fs.readFileSync(path.join(__dirname, 'build/formTimingTracking.js'), { encoding: 'utf-8' })}
 
 formTimingTracking(function (eventData) {
-    window._paq.push(eventData)
+  var trackFromIframe = {{iframeTracking}}; 
+  if(!trackFromIframe){
+    pushToAnalytics(eventData);
+  } else {
+    postIframeMessage(eventData);
+  }
 }, {
   formNameAttribute: '{{formNameAttribute}}',
   fieldNameAttribute: '{{fieldNameAttribute}}',
   eventCategoryPrefix: '{{eventCategoryPrefix}}',
-  iframeTracking: {{iframeTracking}},
 });
       `,
       arguments: [

--- a/templates.js
+++ b/templates.js
@@ -21,18 +21,25 @@ module.exports = {
       template: `
 ${fs.readFileSync(path.join(__dirname, 'build/detectDeadClicks.js'), { encoding: 'utf-8' })}
 
-var unsubscribe = detectDeadClicks(function (target) {
-window._paq.push(['trackEvent', 'UX Research', 'Dead Click', target]);
+var unsubscribe = detectDeadClicks(function (eventData) {
+window._paq.push(eventData);
 
 // unsubscribe();
 }, {
 interval: {{interval}},
 limit: {{limit}},
+iframeTracking: {{iframeTracking}},
 });
       `,
       arguments: [
         { id: 'interval', type: 'number', displayName: 'Time interval', description: 'Number of milliseconds to reset counter', default: 1000 },
         { id: 'limit', type: 'number', displayName: 'Number of clicks needed to trigger subscription', default: 2 },
+        { id: 'iframeTracking',
+        type: 'boolean',
+        displayName: 'Send messages from iframes',
+        description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+        default: false
+        },
       ],
     },
     {

--- a/templates.js
+++ b/templates.js
@@ -384,5 +384,22 @@ videoTrackingHTML5(function(eventData) {
       },
     ],
   },
+  {
+    id: 'iframeTrackingHandler',
+    name: 'Iframe Tracking Handler',
+    description: `
+      This is an iframe tracking handler.
+      Add one of the templates with iframe tracking turned on to the website
+      that will be shown as an iframe and use this handler to catch the messages
+      sent from the iframe on the parent website and turn them into events.
+    `,
+    template: `
+window.addEventListener('message', function(event){ 
+	_paq.push(event.data);
+}, false);  
+    `,
+    arguments: [        
+   ]
+  },
   ]
 };

--- a/templates.js
+++ b/templates.js
@@ -232,12 +232,19 @@ formTimingTracking(function (fieldInteractionData) {
     template: `
 ${fs.readFileSync(path.join(__dirname, 'build/trackCopiedText.js'), { encoding: 'utf-8' })}
 
-trackCopiedText(function (copiedItemText) {
-  var eventData = ["trackEvent","User interaction","Copying text",copiedItemText]
+trackCopiedText(function (eventData) {
     window._paq.push(eventData);
-}, {});
+}, {
+  iframeTracking: {{iframeTracking}},
+});
     `,
-    arguments: [      
+    arguments: [
+      { id: 'iframeTracking',
+      type: 'boolean',
+      displayName: 'Send messages from iframes',
+      description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+      default: false
+      },      
    ],
   },
   {

--- a/templates.js
+++ b/templates.js
@@ -48,13 +48,21 @@ limit: {{limit}},
       template: `
 ${fs.readFileSync(path.join(__dirname, 'build/detectErrorClicks.js'), { encoding: 'utf-8' })}
 
-var unsubscribe = detectErrorClicks(function (target, error) {
-window._paq.push(['trackEvent', 'UX Research', 'Error Click', target]);
+var unsubscribe = detectErrorClicks(function (eventData) {
+window._paq.push(eventData);
 
 // unsubscribe(); // Uncomment this line when you want to finish after first trigger
+}, {
+iframeTracking: {{iframeTracking}},
 });
       `,
-      arguments: []
+      arguments: [        
+        { id: 'iframeTracking',
+        type: 'boolean',
+        displayName: 'Send messages from iframes',
+        description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+        default: false
+        }, ]
     },
     {
       id: 'mouseShake',

--- a/templates.js
+++ b/templates.js
@@ -394,9 +394,12 @@ videoTrackingHTML5(function(eventData) {
       sent from the iframe on the parent website and turn them into events.
     `,
     template: `
-window.addEventListener('message', function(event){ 
-	_paq.push(event.data);
-}, false);  
+    window.addEventListener('message', function(event){ 
+      if(event.data.type === "PiwikPRO")
+      {
+       _paq.push(event.data.payload); 
+      }
+     }, false);  
     `,
     arguments: [        
    ]

--- a/templates.js
+++ b/templates.js
@@ -75,11 +75,18 @@ window._paq.push(['trackEvent', 'UX Research', 'Mouse shake']);
 }, {
 interval: {{interval}},
 threshold: {{threshold}},
+iframeTracking: {{iframeTracking}},
 });
       `,
       arguments: [
         { id: 'interval', type: 'number', displayName: 'Time interval', description: 'Number of milliseconds to reset counter', default: 350 },
         { id: 'threshold', type: 'number', displayName: 'Acceleration of mouse movement threshold', default: 0.01 },
+        { id: 'iframeTracking',
+        type: 'boolean',
+        displayName: 'Send messages from iframes',
+        description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+        default: false
+        }, 
       ],
     },
     {
@@ -94,18 +101,25 @@ threshold: {{threshold}},
       template: `
 ${fs.readFileSync(path.join(__dirname, 'build/detectRageClicks.js'), { encoding: 'utf-8' })}
 
-var unsubscribe = detectRageClicks(function (target) {
-window._paq.push(['trackEvent', 'UX Research', 'Rage click', target]);
+var unsubscribe = detectRageClicks(function (eventData) {
+window._paq.push(eventData);
 
 // unsubscribe(); // Uncomment this line when you want to finish after first trigger
 }, {
 interval: {{interval}},
 limit: {{limit}},
+iframeTracking: {{iframeTracking}},
 });
       `,
       arguments: [
         { id: 'interval', type: 'number', displayName: 'Time interval', description: 'Number of milliseconds to reset counter', default: 750 },
         { id: 'limit', type: 'number', displayName: 'Number of clicks to trigger event', default: 3 },
+        { id: 'iframeTracking',
+        type: 'boolean',
+        displayName: 'Send messages from iframes',
+        description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+        default: false
+        }, 
       ],
     },
     {

--- a/templates.js
+++ b/templates.js
@@ -192,12 +192,13 @@ ${fs.readFileSync(path.join(__dirname, 'build/collectHeatmapClicks.js'), { encod
       template: `
 ${fs.readFileSync(path.join(__dirname, 'build/formTimingTracking.js'), { encoding: 'utf-8' })}
 
-formTimingTracking(function (fieldInteractionData) {
-  var eventData = ['trackEvent', '{{eventCategoryPrefix}}'+fieldInteractionData.formName, fieldInteractionData.fieldName, fieldInteractionData.interactionType, fieldInteractionData.timeSpent/1000 || 0 ]
+formTimingTracking(function (eventData) {
     window._paq.push(eventData)
 }, {
   formNameAttribute: '{{formNameAttribute}}',
   fieldNameAttribute: '{{fieldNameAttribute}}',
+  eventCategoryPrefix: '{{eventCategoryPrefix}}',
+  iframeTracking: {{iframeTracking}},
 });
       `,
       arguments: [
@@ -221,6 +222,12 @@ formTimingTracking(function (fieldInteractionData) {
           default: 'name',
           choices: ['id','name','label','placeholder']
         },
+        { id: 'iframeTracking',
+        type: 'boolean',
+        displayName: 'Send messages from iframes',
+        description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+        default: false
+        },    
       ],
     },
   {

--- a/templates.js
+++ b/templates.js
@@ -43,7 +43,7 @@ limit: {{limit}},
         { id: 'iframeTracking',
         type: 'boolean',
         displayName: 'Send messages from iframes',
-        description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+        description: 'If checked, you won’t send the _paq.push but instead you will send a message to the parent window',
         default: false
         },
       ],
@@ -77,7 +77,7 @@ var unsubscribe = detectErrorClicks(function (eventData) {
         { id: 'iframeTracking',
         type: 'boolean',
         displayName: 'Send messages from iframes',
-        description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+        description: 'If checked, you won’t send the _paq.push but instead you will send a message to the parent window',
         default: false
         }, ]
     },
@@ -115,7 +115,7 @@ threshold: {{threshold}},
         { id: 'iframeTracking',
         type: 'boolean',
         displayName: 'Send messages from iframes',
-        description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+        description: 'If checked, you won’t send the _paq.push but instead you will send a message to the parent window',
         default: false
         }, 
       ],
@@ -154,7 +154,7 @@ limit: {{limit}},
         { id: 'iframeTracking',
         type: 'boolean',
         displayName: 'Send messages from iframes',
-        description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+        description: 'If checked, you won’t send the _paq.push but instead you will send a message to the parent window',
         default: false
         }, 
       ],
@@ -285,7 +285,7 @@ formTimingTracking(function (eventData) {
         { id: 'iframeTracking',
         type: 'boolean',
         displayName: 'Send messages from iframes',
-        description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+        description: 'If checked, you won’t send the _paq.push but instead you will send a message to the parent window',
         default: false
         },    
       ],
@@ -314,7 +314,7 @@ trackCopiedText(function (eventData) {
       { id: 'iframeTracking',
       type: 'boolean',
       displayName: 'Send messages from iframes',
-      description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+      description: 'If checked, you won’t send the _paq.push but instead you will send a message to the parent window',
       default: false
       },      
    ],
@@ -421,7 +421,7 @@ videoTrackingHTML5(function(eventData) {
       { id: 'iframeTracking',
       type: 'boolean',
       displayName: 'Send messages from iframes',
-      description: 'If checked, you won’t send the _paq.push but instead you will send a message',
+      description: 'If checked, you won’t send the _paq.push but instead you will send a message to the parent window',
       default: false
       },
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,14 +5,29 @@ const fs = require('fs');
 const ROOT = path.resolve( __dirname, 'src' );
 const DESTINATION = path.resolve( __dirname, 'build' );
 
-const entry = fs.readdirSync(path.join(__dirname, 'src'))
-  .filter(filename => filename.includes('.'))
-  .map(filename => filename.split('.'))
-  .reduce((acc, next) => {
-    acc[next[0]] = `./src/${next.join('.')}`;
+function readDirectoryContents(dirPath){
 
-    return acc;
-  }, {});
+  const output = fs.readdirSync(path.join(__dirname, dirPath))
+    .filter(filename => filename.includes('.'))
+    .map(filename => filename.split('.'))
+    .reduce((acc, next) => {
+      acc[next[0]] = `./`+dirPath+`/${next.join('.')}`;
+
+      return acc;
+    }, {});
+
+  return output;  
+
+}
+
+const src = readDirectoryContents('src');
+const minified = readDirectoryContents('src/helpers/minified');
+
+const entry = {
+  ...src,
+  ...minified
+};
+
 
 module.exports = {
   mode: 'production',


### PR DESCRIPTION
I've added Iframe communication to most of the templates. Changed the structure of sending values outside so that it would be the same for all the templates which have the Iframe tracking option so that only one handler will be needed. The handler was also added. We send the following in the message data - {type: "PiwikPRO", payload: eventData}  We later use the type to recognise messages from our templates and convert them into events with our handler. 

It can be tested here, not all templates but a few (I tested all of them) - https://multiwp.demopiwikpro.com/kbigos/form-test-iframe/

Dead clicks - click 2 times on something 
Rage clicks - click 3 times on something 
Copied text - copy something 
Form Tracking - click on the search input and click on something else